### PR TITLE
feat: request body 추가 및 security 임시 비활성화

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -19,14 +19,14 @@ repositories {
 dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-jdbc")
 	implementation("org.springframework.boot:spring-boot-starter-data-jpa")
-	implementation("org.springframework.boot:spring-boot-starter-security")
+//	implementation("org.springframework.boot:spring-boot-starter-security")
 	implementation("org.springframework.boot:spring-boot-starter-web")
 	implementation("com.fasterxml.jackson.module:jackson-module-kotlin")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
 	runtimeOnly("com.mysql:mysql-connector-j")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
-	testImplementation("org.springframework.security:spring-security-test")
+//	testImplementation("org.springframework.security:spring-security-test")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/jinyoung/memoserver/controller/MemoController.kt
+++ b/src/main/kotlin/com/jinyoung/memoserver/controller/MemoController.kt
@@ -3,9 +3,7 @@ package com.jinyoung.memoserver.controller
 import com.jinyoung.memoserver.dto.CreateMemoDto
 import com.jinyoung.memoserver.entity.Memo
 import com.jinyoung.memoserver.service.MemoService
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 
 @RestController
 class MemoController(private val memoService: MemoService) {
@@ -15,7 +13,7 @@ class MemoController(private val memoService: MemoService) {
     }
 
     @PostMapping("/memos")
-    fun createMemo(body: CreateMemoDto): Memo {
+    fun createMemo(@RequestBody body: CreateMemoDto): Memo {
         return memoService.createMemo(body)
     }
 }

--- a/src/main/kotlin/com/jinyoung/memoserver/repository/MemoRepository.kt
+++ b/src/main/kotlin/com/jinyoung/memoserver/repository/MemoRepository.kt
@@ -2,6 +2,8 @@ package com.jinyoung.memoserver.repository
 
 import com.jinyoung.memoserver.entity.Memo
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
 
+@Repository
 interface MemoRepository: JpaRepository<Memo, Long> {
 }


### PR DESCRIPTION
**공부한 내용**
- `RestController` vs `Controller`
  - Controller는 주로 View를 전달하기 위해 사용, JSON로 변환하기 위해서는 `ResponseEntity를` 사용
  - `RestController는` `ResponseEntity를` 이미 포함하고 있음, JSON 형태로 반환
- request body를 받아올 때는 `@RequestBody` annotation을 사용하여 body를 받아온다 
- DTO를 엔티티로 변환해서 데이터베이스에 저장하기 위해서는 각각을 생성자로 넣어줌 or `DTO data class`로 